### PR TITLE
2022-2.3-tiled (removed `intake` dependency)

### DIFF
--- a/configs/config-py38.yml
+++ b/configs/config-py38.yml
@@ -1,5 +1,5 @@
 docker_image: "nsls2/linux-anvil-cos7-x86_64:latest"
-env_name: "2022-2.2-py38-tiled"
+env_name: "2022-2.3-py38-tiled"
 conda_env_file: "env-py38.yml"
 conda_binary: "mamba"
 python_version: "3.8"
@@ -21,7 +21,7 @@ zenodo_metadata:
     title: "NSLS-II collection conda environment"
     upload_type: "software"
     description: "NSLS-II collection conda environment"
-    version: 2022-2.2
+    version: 2022-2.3-tiled
     creators:
       - name: Rakitin, Maksim
         affiliation: "Brookhaven National Laboratory"

--- a/configs/config-py39.yml
+++ b/configs/config-py39.yml
@@ -1,5 +1,5 @@
 docker_image: "nsls2/linux-anvil-cos7-x86_64:latest"
-env_name: "2022-2.2-py39-tiled"
+env_name: "2022-2.3-py39-tiled"
 conda_env_file: "env-py39.yml"
 conda_binary: "mamba"
 python_version: "3.9"
@@ -21,7 +21,7 @@ zenodo_metadata:
     title: "NSLS-II collection conda environment"
     upload_type: "software"
     description: "NSLS-II collection conda environment"
-    version: 2022-2.2
+    version: 2022-2.3-tiled
     creators:
       - name: Rakitin, Maksim
         affiliation: "Brookhaven National Laboratory"

--- a/envs/env-py38.yml
+++ b/envs/env-py38.yml
@@ -1,4 +1,4 @@
-name: 2022-2.2-py38-tiled
+name: 2022-2.3-py38-tiled
 channels:
   - conda-forge
 dependencies:
@@ -26,7 +26,7 @@ dependencies:
   - conda-pack
   - csxtools
   - dask
-  - databroker >=2.0.0b2
+  - databroker >=2.0.0b2=*_1
   - dictdiffer
   - distributed
   - doi2bib
@@ -47,7 +47,6 @@ dependencies:
   - igor
   - imageio <2.16.2
   - inflection
-  - intake <=0.6.4
   - ipykernel
   - ipympl >=0.1.1
   - ipython >=7.20.0

--- a/envs/env-py39.yml
+++ b/envs/env-py39.yml
@@ -1,4 +1,4 @@
-name: 2022-2.2-py39-tiled
+name: 2022-2.3-py39-tiled
 channels:
   - conda-forge
 dependencies:
@@ -27,7 +27,7 @@ dependencies:
   - conda-pack
   - csxtools
   - dask
-  - databroker >=2.0.0b2
+  - databroker >=2.0.0b2=*_1
   - dictdiffer
   - distributed
   - doi2bib
@@ -48,7 +48,6 @@ dependencies:
   - igor
   - imageio <2.16.2
   - inflection
-  - intake <=0.6.4
   - ipykernel
   - ipympl >=0.1.1
   - ipython >=7.20.0


### PR DESCRIPTION
Turns out we still have the `intake` dependency in the tiled envs (see failures in https://github.com/NSLS-II-TES/profile_simulated_hardware/pull/13).

Uses https://github.com/conda-forge/databroker-feedstock/pull/33.