### PR TITLE
2022-3.2 env

### DIFF
--- a/configs/config-py39.yml
+++ b/configs/config-py39.yml
@@ -1,5 +1,5 @@
 docker_image: "nsls2/linux-anvil-cos7-x86_64:latest"
-env_name: "2022-3.1-py39-tiled"
+env_name: "2022-3.2-py39-tiled"
 conda_env_file: "env-py39.yml"
 conda_binary: "mamba"
 python_version: "3.9"
@@ -21,7 +21,7 @@ zenodo_metadata:
     title: "NSLS-II collection conda environment"
     upload_type: "software"
     description: "NSLS-II collection conda environment"
-    version: 2022-3.1-tiled
+    version: 2022-3.2-tiled
     creators:
       - name: Rakitin, Maksim
         affiliation: "Brookhaven National Laboratory"

--- a/envs/env-py39.yml
+++ b/envs/env-py39.yml
@@ -1,4 +1,4 @@
-name: 2022-3.1-py39-tiled
+name: 2022-3.2-py39-tiled
 channels:
   - conda-forge
 dependencies:
@@ -27,12 +27,12 @@ dependencies:
   - conda-pack
   - csxtools
   - dask
-  - databroker >=2.0.0b8=*_1
+  - databroker >=2.0.0b11=*_0
   - dictdiffer
   - distributed
   - doi2bib
   - dpcmaps
-  # - edrixs
+  - edrixs
   - eiger-io
   - event-model >=1.18.0
   - fabio
@@ -82,7 +82,7 @@ dependencies:
   - openpyxl
   - ophyd >=1.7.0
   - papermill
-  # - pdfstream
+  - pdfstream >=0.6.1
   - peakutils
   - periodictable
   - photutils
@@ -124,7 +124,7 @@ dependencies:
   - suitcase-tiff >=0.4.0
   - suitcase-utils
   - sympy
-  - tiled >=0.1.0a70
+  - tiled >=0.1.0a75
   - toml
   - tomopy >=1.11
   - tornado
@@ -139,8 +139,7 @@ dependencies:
   - zbar  # dependency of pyzbar
   # Simulation packages:
   - oscars
-  # NOTE: shadow3 causes conflict issues with scipy>=1.8.
-  # - shadow3
+  - shadow3
   - srwpy
   - xrt
   #***************************************************************************#
@@ -164,7 +163,7 @@ dependencies:
   - hklpy  # [linux]
   - hxnfly >=0.0.10
   - ppmac
-  # - xpdacq
+  - xpdacq >=1.1.2
   # Debugging tools:
   - hunter
   - logging_tree


### PR DESCRIPTION
Corresponding update to the non-tiled env: https://github.com/nsls2-conda-envs/nsls2-collection/pull/11.

### Updates
- pins `pdfstream` to v0.6.1 or newer (needed by PDF/XPD)
- uncomments `edrixs` and `shadow3` (both should be available in the conda-forge channel and compatible with latest `scipy`)

### Diffs
```diff
diff envs/env-py39.yml ../nsls2-collection/envs/env-py39.yml
1c1
< name: 2022-3.2-py39-tiled
---
> name: 2022-3.2-py39
18c18
<   - bluesky-kafka >=0.9.1
---
>   - bluesky-kafka >=0.9.1  # [not win]
22c22
<   # - bluesky-queueserver-api >=0.0.8
---
>   # - bluesky-queueserver-api
30c30,31
<   - databroker >=2.0.0b11=*_0
---
>   - databroker >=1.2.5,<2.0.0a
>   - databroker-pack
50a52
>   - intake <=0.6.4
127d128
<   - tiled >=0.1.0a75
```