### PR TITLE
Python 3.10 conda env

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9"]
+        python-version: ["3.10"]
       fail-fast: false
     env:
       TZ: America/New_York

--- a/configs/config-py310.yml
+++ b/configs/config-py310.yml
@@ -1,0 +1,29 @@
+docker_image: "nsls2/linux-anvil-cos7-x86_64:latest"
+env_name: "2022-3.2-py310-tiled"
+conda_env_file: "env-py310.yml"
+conda_binary: "mamba"
+python_version: "3.10"
+pkg_name: ""
+pkg_version: ""
+# extra_packages: "nsls2-collection=2021C2.0=*_0 tmate mamba"
+extra_packages: "tmate mamba"
+channels: "-c conda-forge"
+#extra_cmd_before_install: "yum install mesa-libGL mesa-libGL-devel -y"
+extra_cmd_before_install: "yum install mesa-libGL -y"
+extra_cmd_after_install: "conda remove perl --force -y"
+docker_upload:
+  - ghcr
+  - dockerhub
+  # - quay
+zenodo_upload: "no"
+zenodo_metadata:
+  metadata:
+    title: "NSLS-II collection conda environment"
+    upload_type: "software"
+    description: "NSLS-II collection conda environment"
+    version: 2022-3.2-tiled
+    creators:
+      - name: Rakitin, Maksim
+        affiliation: "Brookhaven National Laboratory"
+      - name: Bischof, Garrett
+        affiliation: "Brookhaven National Laboratory"

--- a/envs/env-py310.yml
+++ b/envs/env-py310.yml
@@ -1,0 +1,176 @@
+name: 2022-3.2-py310-tiled
+channels:
+  - conda-forge
+dependencies:
+  #***************************************************************************#
+  #                                                                           #
+  #            Dependencies from the `nsls2-analysis` metapackage             #
+  #                                                                           #
+  #***************************************************************************#
+  - python >=3.10,<3.11
+  - amostra <=1.0
+  - ansiwrap
+  - area-detector-handlers >=0.0.9
+  - arvpyf
+  - attrs >=18.0
+  - black
+  - bluesky >=1.9.0
+  - bluesky-kafka >=0.9.1
+  - bluesky-live >=0.0.8
+  - bluesky-queueserver >=0.0.16
+  # TODO: sort out conflicts with bluesky-queueserver-api
+  # - bluesky-queueserver-api >=0.0.8
+  - bluesky-widgets >=0.0.13
+  - boto3
+  - chxtools
+  - cmasher
+  - conda-pack
+  - csxtools
+  - dask
+  - databroker >=2.0.0b11=*_0
+  - dictdiffer
+  - distributed
+  - doi2bib
+  - dpcmaps
+  - edrixs
+  - eiger-io
+  - event-model >=1.18.0
+  - fabio
+  - ffmpeg >=4.0
+  - flake8
+  - globus-sdk
+  - graphviz
+  - grid-strategy
+  - h5py !=3.4
+  - hdf5-external-filter-plugins-bitshuffle
+  - hdf5-external-filter-plugins-lz4
+  - hxntools >=0.5.2
+  - igor
+  - imageio <2.16.2
+  - inflection
+  - ipykernel
+  - ipympl >=0.1.1
+  - ipython >=7.20.0
+  - ipywidgets >=7.2.1
+  - isort
+  - ispyb
+  - isstools
+  - jedi
+  - jupyter
+  - jupyterlab
+  - legacy-suitcase
+  - lixtools
+  - lmfit
+  - lxml
+  - matplotlib >=3.1.0,!=3.3
+  - memory_profiler
+  - mendeleev
+  - modestimage
+  - mxtools >=0.0.6
+  - napari >=0.4.11
+  - natsort
+  - netcdf4
+  - nexpy >=0.14.1
+  - nodejs
+  - nsls2-detector-handlers >=0.0.2
+  - nslsii >=0.7.0
+  - numexpr
+  - numpy >=1.14.0
+  - nyxtools >=0.0.10
+  - oct2py
+  - opencv
+  - openpyxl
+  - ophyd >=1.7.0
+  - papermill
+  - pdfstream >=0.6.1=*_2
+  - peakutils
+  - periodictable
+  - photutils
+  - pillow
+  - pocl  # needed by pyopencl, used by the `xrt` package
+  - prefect
+  - py4xs
+  - pycentroids  # [not win]
+  - pyepics >=3.4.2
+  - pyfai
+  - pyfftw
+  - pymongo >=3.7
+  - pypdf2
+  - pyqt >=5.9.0
+  - pyqtgraph
+  - pystackreg
+  - python
+  - python-graphviz
+  - pyxrf >=1.0.18
+  - pyzbar  # [not win]
+  - qt >=5.9.0
+  - redis-py
+  - reportlab
+  - requests
+  - sasview
+  - scikit-beam >=0.0.24
+  - scikit-learn
+  - scipy >=1.8.0
+  - silx
+  - sixtools
+  - slackclient
+  - smi-analysis
+  - suitcase-csv
+  - suitcase-json-metadata
+  - suitcase-jsonl
+  - suitcase-mongo
+  - suitcase-msgpack
+  - suitcase-specfile
+  - suitcase-tiff >=0.4.0
+  - suitcase-utils
+  - sympy
+  - tiled >=0.1.0a75
+  - toml
+  - tomopy >=1.11
+  - tornado
+  - tqdm
+  - tzlocal !=3.0
+  - xlrd
+  - xlwt
+  - xmidas >=0.1.2
+  - xpdan >=0.8.2
+  - xray-vision >=0.1.1
+  - xraylarch >=0.9.58
+  - zbar  # dependency of pyzbar
+  # Simulation packages:
+  - oscars
+  - shadow3
+  - srwpy
+  - xrt
+  #***************************************************************************#
+  #                                                                           #
+  #            Dependencies from the `nsls2-collection` metapackage           #
+  #                                                                           #
+  #***************************************************************************#
+  - bloptools
+  - bluesky-darkframes
+  - caproto
+  - happi
+  - pexpect
+  # - pydm
+  - pyolog >=4.5.0
+  - pyserial
+  - python-confluent-kafka  # [not win]
+  - pyzenodo3
+  - simple-pid
+  - slack-sdk
+  # Beamline-specific packages
+  - hklpy  # [linux]
+  - hxnfly >=0.0.10
+  - ppmac
+  - xpdacq >=1.1.2
+  # Debugging tools:
+  - hunter
+  - logging_tree
+  # Profiling tools:
+  - line_profiler
+  - pyinstrument
+  - pyperformance
+  - pip
+  - pip:
+    - bluesky-queueserver-api


### PR DESCRIPTION
A companion of https://github.com/nsls2-conda-envs/nsls2-collection/pull/12.

### Diffs
```diff
$ diff configs/config-py39.yml configs/config-py310.yml
2,3c2,3
< env_name: "2022-3.2-py39-tiled"
< conda_env_file: "env-py39.yml"
---
> env_name: "2022-3.2-py310-tiled"
> conda_env_file: "env-py310.yml"
5c5
< python_version: "3.9"
---
> python_version: "3.10"
```

```diff
$ diff envs/env-py39.yml envs/env-py310.yml
1c1
< name: 2022-3.2-py39-tiled
---
> name: 2022-3.2-py310-tiled
10c10
<   - python >=3.9,<3.10
---
>   - python >=3.10,<3.11
85c85
<   - pdfstream >=0.6.1
---
>   - pdfstream >=0.6.1=*_2
```

```diff
$ diff envs/env-py310.yml ../nsls2-collection/envs/env-py310.yml
1c1
< name: 2022-3.2-py310-tiled
---
> name: 2022-3.2-py310
18c18
<   - bluesky-kafka >=0.9.1
---
>   - bluesky-kafka >=0.9.1  # [not win]
22c22
<   # - bluesky-queueserver-api >=0.0.8
---
>   # - bluesky-queueserver-api
30c30,31
<   - databroker >=2.0.0b11=*_0
---
>   - databroker >=1.2.5,<2.0.0a
>   - databroker-pack
50a52
>   - intake <=0.6.4
127d128
<   - tiled >=0.1.0a75
```