### PR TITLE
2023-1.2 envs

### DIFF
--- a/configs/config-py310.yml
+++ b/configs/config-py310.yml
@@ -1,5 +1,5 @@
 docker_image: "nsls2/linux-anvil-cos7-x86_64:latest"
-env_name: "2023-1.1-py310-tiled"
+env_name: "2023-1.2-py310-tiled"
 conda_env_file: "env-py310.yml"
 conda_binary: "mamba"
 python_version: "3.10"
@@ -19,7 +19,7 @@ zenodo_metadata:
     title: "NSLS-II collection conda environment"
     upload_type: "software"
     description: "NSLS-II collection conda environment"
-    version: 2023-1.1-tiled
+    version: 2023-1.2-tiled
     creators:
       - name: Rakitin, Maksim
         affiliation: "Brookhaven National Laboratory"

--- a/configs/config-py39.yml
+++ b/configs/config-py39.yml
@@ -1,5 +1,5 @@
 docker_image: "nsls2/linux-anvil-cos7-x86_64:latest"
-env_name: "2023-1.1-py39-tiled"
+env_name: "2023-1.2-py39-tiled"
 conda_env_file: "env-py39.yml"
 conda_binary: "mamba"
 python_version: "3.9"
@@ -19,7 +19,7 @@ zenodo_metadata:
     title: "NSLS-II collection conda environment"
     upload_type: "software"
     description: "NSLS-II collection conda environment"
-    version: 2023-1.1-tiled
+    version: 2023-1.2-tiled
     creators:
       - name: Rakitin, Maksim
         affiliation: "Brookhaven National Laboratory"

--- a/envs/env-py310.yml
+++ b/envs/env-py310.yml
@@ -15,7 +15,7 @@ dependencies:
   - attrs >=18.0
   - black
   - bluesky >=1.10.0
-  - bluesky-kafka >=0.9.1
+  - bluesky-kafka >=0.10.0
   - bluesky-live >=0.0.8
   - bluesky-queueserver >=0.0.18
   - bluesky-queueserver-api >=0.0.9
@@ -26,7 +26,7 @@ dependencies:
   - conda-pack
   - csxtools >=0.1.18
   - dask
-  - databroker >=2.0.0b14=*_0
+  - databroker >=2.0.0b15=*_0
   - dictdiffer
   - distributed
   - doi2bib
@@ -129,7 +129,7 @@ dependencies:
   - suitcase-tiff >=0.4.0
   - suitcase-utils
   - sympy
-  - tiled >=0.1.0a83
+  - tiled >=0.1.0a85
   - toml
   - tomopy >=1.12.2
   - tornado

--- a/envs/env-py310.yml
+++ b/envs/env-py310.yml
@@ -1,4 +1,4 @@
-name: 2023-1.1-py310-tiled
+name: 2023-1.2-py310-tiled
 channels:
   - conda-forge
 dependencies:
@@ -24,9 +24,9 @@ dependencies:
   - chxtools
   - cmasher
   - conda-pack
-  - csxtools
+  - csxtools >=0.1.18
   - dask
-  - databroker >=2.0.0b13=*_0
+  - databroker >=2.0.0b14=*_0
   - dictdiffer
   - distributed
   - doi2bib
@@ -43,7 +43,7 @@ dependencies:
   - h5py !=3.4
   - hdf5-external-filter-plugins-bitshuffle
   - hdf5-external-filter-plugins-lz4
-  - hxntools >=0.5.2
+  - hxntools >=0.6.1
   - igor
   - imageio <2.16.2
   - inflection
@@ -65,7 +65,7 @@ dependencies:
   - memory_profiler
   - mendeleev
   - modestimage
-  - mxtools >=1.0.1
+  - mxtools >=1.0.2
   - napari >=0.4.17
   - natsort
   - netcdf4
@@ -75,11 +75,16 @@ dependencies:
   - nslsii >=0.9.0
   - numexpr
   - numpy >=1.20
-  - nyxtools >=0.0.11
+  - nyxtools >=0.0.12
   - oct2py
   - opencv
-  - openpyxl
   - ophyd >=1.7.0
+  # pandas and deps
+  - pandas
+  - openpyxl  # used by pandas .to_excel()
+  - pyarrow  # used by pandas .to_parquet()
+  - pytables  # used by pandas .to_hdf()
+  # end of pandas deps
   - papermill
   - pdfstream >=0.6.2
   - peakutils
@@ -100,7 +105,6 @@ dependencies:
   - pyqt >=5.12.0
   - pyqtgraph
   - pystackreg
-  - python
   - python-graphviz
   - pyxrf >=1.0.21
   - pyzbar
@@ -125,7 +129,7 @@ dependencies:
   - suitcase-tiff >=0.4.0
   - suitcase-utils
   - sympy
-  - tiled >=0.1.0a80
+  - tiled >=0.1.0a83
   - toml
   - tomopy >=1.12.2
   - tornado
@@ -135,7 +139,7 @@ dependencies:
   - xlwt
   - xmidas >=0.1.2
   - xray-vision >=0.1.1
-  - xraylarch >=0.9.60
+  - xraylarch >=0.9.66
   - zbar  # dependency of pyzbar
   # Simulation packages:
   - oscars
@@ -161,7 +165,7 @@ dependencies:
   - slack-sdk
   # Beamline-specific packages
   - hklpy  # [linux]
-  - hxnfly >=0.0.10
+  - hxnfly >=0.0.11
   - ppmac
   - xpdacq >=1.1.4
   # Debugging tools:
@@ -173,4 +177,5 @@ dependencies:
   - pyperformance
   # ML:
   - gpytorch
+  - ortools-python
   - pytorch

--- a/envs/env-py39.yml
+++ b/envs/env-py39.yml
@@ -1,4 +1,4 @@
-name: 2023-1.1-py39-tiled
+name: 2023-1.2-py39-tiled
 channels:
   - conda-forge
 dependencies:
@@ -24,9 +24,9 @@ dependencies:
   - chxtools
   - cmasher
   - conda-pack
-  - csxtools
+  - csxtools >=0.1.18
   - dask
-  - databroker >=2.0.0b13=*_0
+  - databroker >=2.0.0b14=*_0
   - dictdiffer
   - distributed
   - doi2bib
@@ -43,7 +43,7 @@ dependencies:
   - h5py !=3.4
   - hdf5-external-filter-plugins-bitshuffle
   - hdf5-external-filter-plugins-lz4
-  - hxntools >=0.5.2
+  - hxntools >=0.6.1
   - igor
   - imageio <2.16.2
   - inflection
@@ -65,7 +65,7 @@ dependencies:
   - memory_profiler
   - mendeleev
   - modestimage
-  - mxtools >=1.0.1
+  - mxtools >=1.0.2
   - napari >=0.4.17
   - natsort
   - netcdf4
@@ -75,11 +75,16 @@ dependencies:
   - nslsii >=0.9.0
   - numexpr
   - numpy >=1.20
-  - nyxtools >=0.0.11
+  - nyxtools >=0.0.12
   - oct2py
   - opencv
-  - openpyxl
   - ophyd >=1.7.0
+  # pandas and deps
+  - pandas
+  - openpyxl  # used by pandas .to_excel()
+  - pyarrow  # used by pandas .to_parquet()
+  - pytables  # used by pandas .to_hdf()
+  # end of pandas deps
   - papermill
   - pdfstream >=0.6.2
   - peakutils
@@ -100,7 +105,6 @@ dependencies:
   - pyqt >=5.12.0
   - pyqtgraph
   - pystackreg
-  - python
   - python-graphviz
   - pyxrf >=1.0.21
   - pyzbar
@@ -125,7 +129,7 @@ dependencies:
   - suitcase-tiff >=0.4.0
   - suitcase-utils
   - sympy
-  - tiled >=0.1.0a80
+  - tiled >=0.1.0a83
   - toml
   - tomopy >=1.12.2
   - tornado
@@ -135,7 +139,7 @@ dependencies:
   - xlwt
   - xmidas >=0.1.2
   - xray-vision >=0.1.1
-  - xraylarch >=0.9.60
+  - xraylarch >=0.9.66
   - zbar  # dependency of pyzbar
   # Simulation packages:
   - oscars
@@ -161,7 +165,7 @@ dependencies:
   - slack-sdk
   # Beamline-specific packages
   - hklpy  # [linux]
-  - hxnfly >=0.0.10
+  - hxnfly >=0.0.11
   - ppmac
   - xpdacq >=1.1.4
   # Debugging tools:
@@ -173,4 +177,5 @@ dependencies:
   - pyperformance
   # ML:
   - gpytorch
+  - ortools-python
   - pytorch

--- a/envs/env-py39.yml
+++ b/envs/env-py39.yml
@@ -15,7 +15,7 @@ dependencies:
   - attrs >=18.0
   - black
   - bluesky >=1.10.0
-  - bluesky-kafka >=0.9.1
+  - bluesky-kafka >=0.10.0
   - bluesky-live >=0.0.8
   - bluesky-queueserver >=0.0.18
   - bluesky-queueserver-api >=0.0.9
@@ -26,7 +26,7 @@ dependencies:
   - conda-pack
   - csxtools >=0.1.18
   - dask
-  - databroker >=2.0.0b14=*_0
+  - databroker >=2.0.0b15=*_0
   - dictdiffer
   - distributed
   - doi2bib
@@ -129,7 +129,7 @@ dependencies:
   - suitcase-tiff >=0.4.0
   - suitcase-utils
   - sympy
-  - tiled >=0.1.0a83
+  - tiled >=0.1.0a85
   - toml
   - tomopy >=1.12.2
   - tornado


### PR DESCRIPTION
Adds:
- `ortools-python` (https://github.com/google/or-tools)
- `pytables` (required by pandas to read/write a dataframe from/to hdf5)