### PR TITLE
2023-1.3 envs

### DIFF
--- a/configs/config-py310.yml
+++ b/configs/config-py310.yml
@@ -1,5 +1,5 @@
-docker_image: "nsls2/linux-anvil-cos7-x86_64:latest"
-env_name: "2023-1.2-py310-tiled"
+docker_image: "quay.io/condaforge/linux-anvil-cos7-x86_64:latest"
+env_name: "2023-1.3-py310-tiled"
 conda_env_file: "env-py310.yml"
 conda_binary: "mamba"
 python_version: "3.10"
@@ -19,7 +19,7 @@ zenodo_metadata:
     title: "NSLS-II collection conda environment"
     upload_type: "software"
     description: "NSLS-II collection conda environment"
-    version: 2023-1.2-tiled
+    version: 2023-1.3-tiled
     creators:
       - name: Rakitin, Maksim
         affiliation: "Brookhaven National Laboratory"

--- a/configs/config-py39.yml
+++ b/configs/config-py39.yml
@@ -1,5 +1,5 @@
-docker_image: "nsls2/linux-anvil-cos7-x86_64:latest"
-env_name: "2023-1.2-py39-tiled"
+docker_image: "quay.io/condaforge/linux-anvil-cos7-x86_64:latest"
+env_name: "2023-1.3-py39-tiled"
 conda_env_file: "env-py39.yml"
 conda_binary: "mamba"
 python_version: "3.9"
@@ -19,7 +19,7 @@ zenodo_metadata:
     title: "NSLS-II collection conda environment"
     upload_type: "software"
     description: "NSLS-II collection conda environment"
-    version: 2023-1.2-tiled
+    version: 2023-1.3-tiled
     creators:
       - name: Rakitin, Maksim
         affiliation: "Brookhaven National Laboratory"

--- a/envs/env-py310.yml
+++ b/envs/env-py310.yml
@@ -1,4 +1,4 @@
-name: 2023-1.2-py310-tiled
+name: 2023-1.3-py310-tiled
 channels:
   - conda-forge
 dependencies:
@@ -25,6 +25,8 @@ dependencies:
   - cmasher
   - conda-pack
   - csxtools >=0.1.18
+  - dash
+  - dash-bootstrap-components
   - dask
   - databroker >=2.0.0b15=*_0
   - dictdiffer

--- a/envs/env-py310.yml
+++ b/envs/env-py310.yml
@@ -104,13 +104,13 @@ dependencies:
   - pymcr
   - pymongo >=3.7
   - pypdf2
-  - pyqt >=5.15.0
+  - pyqt >=5.12.0
   - pyqtgraph
   - pystackreg
   - python-graphviz
   - pyxrf >=1.0.23
   - pyzbar
-  - qt >=5.15.0
+  - qt >=5.12.0
   - redis-py
   - reportlab
   - requests
@@ -178,6 +178,7 @@ dependencies:
   - pyinstrument
   - pyperformance
   # ML:
+  - botorch
   - gpytorch
   - ortools-python
   - pytorch

--- a/envs/env-py310.yml
+++ b/envs/env-py310.yml
@@ -131,7 +131,7 @@ dependencies:
   - suitcase-tiff >=0.4.0
   - suitcase-utils
   - sympy
-  - tiled >=0.1.0a85
+  - tiled >=0.1.0a91
   - toml
   - tomopy >=1.12.2
   - tornado

--- a/envs/env-py310.yml
+++ b/envs/env-py310.yml
@@ -104,13 +104,13 @@ dependencies:
   - pymcr
   - pymongo >=3.7
   - pypdf2
-  - pyqt >=5.12.0
+  - pyqt >=5.15.0
   - pyqtgraph
   - pystackreg
   - python-graphviz
-  - pyxrf >=1.0.21
+  - pyxrf >=1.0.23
   - pyzbar
-  - qt >=5.12.0
+  - qt >=5.15.0
   - redis-py
   - reportlab
   - requests

--- a/envs/env-py39.yml
+++ b/envs/env-py39.yml
@@ -1,4 +1,4 @@
-name: 2023-1.2-py39-tiled
+name: 2023-1.3-py39-tiled
 channels:
   - conda-forge
 dependencies:
@@ -25,6 +25,8 @@ dependencies:
   - cmasher
   - conda-pack
   - csxtools >=0.1.18
+  - dash
+  - dash-bootstrap-components
   - dask
   - databroker >=2.0.0b15=*_0
   - dictdiffer

--- a/envs/env-py39.yml
+++ b/envs/env-py39.yml
@@ -104,13 +104,13 @@ dependencies:
   - pymcr
   - pymongo >=3.7
   - pypdf2
-  - pyqt >=5.15.0
+  - pyqt >=5.12.0
   - pyqtgraph
   - pystackreg
   - python-graphviz
   - pyxrf >=1.0.23
   - pyzbar
-  - qt >=5.15.0
+  - qt >=5.12.0
   - redis-py
   - reportlab
   - requests
@@ -178,6 +178,7 @@ dependencies:
   - pyinstrument
   - pyperformance
   # ML:
+  - botorch
   - gpytorch
   - ortools-python
   - pytorch

--- a/envs/env-py39.yml
+++ b/envs/env-py39.yml
@@ -131,7 +131,7 @@ dependencies:
   - suitcase-tiff >=0.4.0
   - suitcase-utils
   - sympy
-  - tiled >=0.1.0a85
+  - tiled >=0.1.0a91
   - toml
   - tomopy >=1.12.2
   - tornado

--- a/envs/env-py39.yml
+++ b/envs/env-py39.yml
@@ -104,13 +104,13 @@ dependencies:
   - pymcr
   - pymongo >=3.7
   - pypdf2
-  - pyqt >=5.12.0
+  - pyqt >=5.15.0
   - pyqtgraph
   - pystackreg
   - python-graphviz
-  - pyxrf >=1.0.21
+  - pyxrf >=1.0.23
   - pyzbar
-  - qt >=5.12.0
+  - qt >=5.15.0
   - redis-py
   - reportlab
   - requests


### PR DESCRIPTION
Add `dash` libraries.
Switch to use conda-forge's image used for feedstocks.
Bump `pyxrf` version to 1.0.23 and `qt`/`pyqt` to ~5.15~ 5.12 (v5.15 caused some conflicts with other packages, so we'll switch back to v5.12 to unblock the new env packaging).

A peer of https://github.com/nsls2-conda-envs/nsls2-collection/pull/18.