### PR TITLE
2023-3.2: pin `sqlalchemy` to >=2.0.20

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -79,7 +79,7 @@ jobs:
       - name: render config
         run: |
           # For reference: https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html.
-          set -vxeuo pipefail
+          set -vxeo pipefail
 
           env_name=$(cat configs/config-py${PYTHONVER}.yml | shyaml get-value env_name)
           export CONDA_PACK_ENV_NAME="${env_name}"

--- a/configs/config-py310.yml
+++ b/configs/config-py310.yml
@@ -1,5 +1,5 @@
 docker_image: "quay.io/condaforge/linux-anvil-cos7-x86_64:latest"
-env_name: "2023-3.1-py310-tiled"
+env_name: "2023-3.2-py310-tiled"
 conda_env_file: "env-py310.yml"
 conda_binary: "mamba"
 python_version: "3.10"
@@ -19,9 +19,9 @@ zenodo_metadata:
     title: "NSLS-II collection conda environment"
     upload_type: "software"
     description: "NSLS-II collection conda environment"
-    version: 2023-3.1-tiled
+    version: 2023-3.2-tiled
     creators:
-      - name: Rakitin, Maksim
+      - name: Rakitin, Max
         affiliation: "Brookhaven National Laboratory"
       - name: Bischof, Garrett
         affiliation: "Brookhaven National Laboratory"

--- a/envs/env-py310.yml
+++ b/envs/env-py310.yml
@@ -8,6 +8,7 @@ dependencies:
   #                                                                           #
   #***************************************************************************#
   - python >=3.10,<3.11
+  - algotom
   - amostra <=1.0
   - ansiwrap
   - area-detector-handlers >=0.0.9
@@ -38,10 +39,11 @@ dependencies:
   - dask-xgboost
   - databroker >=2.0.0b30
   - dictdiffer
+  - discorpy
   - distributed
   - doi2bib
   - dpcmaps
-  - edrixs
+  # - edrixs  # conflicts caused by the latest numexpr, to resolve later.
   - eiger-io
   - event-model >=1.19.2
   - fabio
@@ -85,7 +87,7 @@ dependencies:
   - nodejs
   - nsls2-detector-handlers >=0.0.3
   - nslsii >=0.9.1
-  - numexpr
+  - numexpr >=2.8.0
   - numpy >=1.20
   - nyxtools >=0.0.12
   - oct2py

--- a/envs/env-py310.yml
+++ b/envs/env-py310.yml
@@ -1,4 +1,4 @@
-name: 2023-3.1-py310-tiled
+name: 2023-3.2-py310-tiled
 channels:
   - conda-forge
 dependencies:
@@ -138,6 +138,7 @@ dependencies:
   - sixtools
   - slackclient
   - smi-analysis
+  - sqlalchemy >=2.0.20
   - suitcase-csv
   - suitcase-json-metadata
   - suitcase-jsonl
@@ -193,7 +194,7 @@ dependencies:
   - kkcalc
   - ppmac
   - pychx >=4.1.2
-  - xpdacq >=1.1.4
+  - xpdacq ==1.0.0
   # Debugging tools:
   - hunter
   - logging_tree

--- a/envs/env-py310.yml
+++ b/envs/env-py310.yml
@@ -101,7 +101,7 @@ dependencies:
   - pytables  # used by pandas .to_hdf()
   # end of pandas deps
   - papermill
-  - pdfstream >=0.6.2
+  - pdfstream ==0.5.2  # same as in the 2022-2.0-py37 env, https://zenodo.org/records/6462525/files/2022-2.0-py37.yml
   - peakutils
   - periodictable
   - photutils


### PR DESCRIPTION
Per report in NSLS2 Slack.

Closes #21