### PR TITLE
Add ipyaggrid

### DIFF
--- a/envs/env-py310.yml
+++ b/envs/env-py310.yml
@@ -62,6 +62,7 @@ dependencies:
   - igor
   - imageio
   - inflection
+  - ipyaggrid
   - ipykernel
   - ipympl >=0.1.1
   - ipython >=7.20.0

--- a/envs/env-py311.yml
+++ b/envs/env-py311.yml
@@ -62,6 +62,7 @@ dependencies:
   - igor
   - imageio
   - inflection
+  - ipyaggrid
   - ipykernel
   - ipympl >=0.1.1
   - ipython >=7.20.0


### PR DESCRIPTION
ipyaggrid is a thin Python wrapper around [AG grid, a performant JS library for interactive tables](https://www.ag-grid.com/).  in-development data browsing widgets at SST1 would benefit from using ipyaggrid.