### PR TITLE
2024-2.3 envs

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -83,6 +83,39 @@ jobs:
           conda config --show
           printenv | sort
 
+      - name: Add packages for py311
+        if: matrix.python-version == '3.11'
+        run: |
+          conda install -c conda-forge \
+            "bloptools>=0.7.0" \
+            "bluesky-darkframes>=0.6.0" \
+            caproto \
+            emojis \
+            happi \
+            pexpect \
+            "pyolog>=4.5.0" \
+            pyserial \
+            python-confluent-kafka \
+            pyzenodo3 \
+            simple-pid \
+            slack-sdk \
+            hklpy \
+            "hxnfly>=0.0.11" \
+            kkcalc \
+            ppmac \
+            "pychx>=4.3.1" \
+            "xpdacq==1.0.0" \
+            hunter \
+            logging_tree \
+            line_profiler \
+            pyinstrument \
+            pyperformance \
+            botorch \
+            gpytorch \
+            ortools-python \
+            pytorch \
+            scikit-optimize
+
       - name: Export files
         run: |
           set -vxeo pipefail

--- a/configs/config-py310.yml
+++ b/configs/config-py310.yml
@@ -1,5 +1,5 @@
 docker_image: "quay.io/condaforge/linux-anvil-cos7-x86_64:latest"
-env_name: "2024-2.2-py310-tiled"
+env_name: "2024-2.3-py310-tiled"
 conda_env_file: "env-py310.yml"
 conda_binary: "mamba"
 python_version: "3.10"
@@ -19,7 +19,7 @@ zenodo_metadata:
     title: "NSLS-II collection conda environment"
     upload_type: "software"
     description: "NSLS-II collection conda environment"
-    version: 2024-2.2-tiled
+    version: 2024-2.3-tiled
     creators:
       - name: Rakitin, Max
         affiliation: "Brookhaven National Laboratory"

--- a/configs/config-py311.yml
+++ b/configs/config-py311.yml
@@ -1,5 +1,5 @@
 docker_image: "quay.io/condaforge/linux-anvil-cos7-x86_64:latest"
-env_name: "2024-2.2-py311-tiled"
+env_name: "2024-2.3-py311-tiled"
 conda_env_file: "env-py311.yml"
 conda_binary: "mamba"
 python_version: "3.11"
@@ -19,7 +19,7 @@ zenodo_metadata:
     title: "NSLS-II collection conda environment"
     upload_type: "software"
     description: "NSLS-II collection conda environment"
-    version: 2024-2.2-tiled
+    version: 2024-2.3-tiled
     creators:
       - name: Rakitin, Max
         affiliation: "Brookhaven National Laboratory"

--- a/configs/config-py312.yml
+++ b/configs/config-py312.yml
@@ -1,5 +1,5 @@
 docker_image: "quay.io/condaforge/linux-anvil-cos7-x86_64:latest"
-env_name: "2024-2.2-py312-tiled"
+env_name: "2024-2.3-py312-tiled"
 conda_env_file: "env-py312.yml"
 conda_binary: "mamba"
 python_version: "3.12"
@@ -19,7 +19,7 @@ zenodo_metadata:
     title: "NSLS-II collection conda environment"
     upload_type: "software"
     description: "NSLS-II collection conda environment"
-    version: 2024-2.2-tiled
+    version: 2024-2.3-tiled
     creators:
       - name: Rakitin, Max
         affiliation: "Brookhaven National Laboratory"

--- a/envs/env-py310.yml
+++ b/envs/env-py310.yml
@@ -15,6 +15,7 @@ dependencies:
   - diffpy.structure
   - event-model>=1.21
   - hdf5-external-filter-plugins
+  - julia
   - maggma >=0.66
   - mp-api >=0.41.2
   - pychx >=4.3.1

--- a/envs/env-py310.yml
+++ b/envs/env-py310.yml
@@ -19,6 +19,7 @@ dependencies:
   - maggma >=0.66
   - mp-api >=0.41.2
   - pychx >=4.3.1
+  - pycryptodome
   - pyfai >=2024.5.0
   - pymatgen >=2024.5.1
   - pyobjcryst

--- a/envs/env-py310.yml
+++ b/envs/env-py310.yml
@@ -12,6 +12,7 @@ dependencies:
   - distributed >=2023.9.0
   - databroker >=2.0.0b45
   - diffpy.pdffit2
+  - diffpy.pdfgui
   - diffpy.structure
   - event-model>=1.21
   - hdf5-external-filter-plugins

--- a/envs/env-py310.yml
+++ b/envs/env-py310.yml
@@ -7,6 +7,7 @@ dependencies:
   - bloptools >=0.7.0
   - blosc-hdf5-plugin
   - conftrak >=0.0.9
+  - cookiecutter
   - dask >=2023.9.0
   - distributed >=2023.9.0
   - databroker >=2.0.0b45

--- a/envs/env-py310.yml
+++ b/envs/env-py310.yml
@@ -1,4 +1,4 @@
-name: 2024-2.2-py310-tiled
+name: 2024-2.3-py310-tiled
 channels:
   - conda-forge
 dependencies:
@@ -12,6 +12,7 @@ dependencies:
   - databroker >=2.0.0b45
   - diffpy.pdffit2
   - diffpy.structure
+  - event-model>=1.21
   - hdf5-external-filter-plugins
   - maggma >=0.66
   - mp-api >=0.41.2
@@ -211,7 +212,6 @@ dependencies:
   - envisage=6.0.1=pyhd8ed1ab_0
   - epics-base=7.0.7.0=h2dfad98_0
   - et_xmlfile=1.1.0=pyhd8ed1ab_0
-  - event-model=1.20.0=pyhd8ed1ab_0
   - exceptiongroup=1.2.0=pyhd8ed1ab_2
   - executing=2.0.1=pyhd8ed1ab_0
   - expat=2.5.0=hcb278e6_1

--- a/envs/env-py311.yml
+++ b/envs/env-py311.yml
@@ -1,4 +1,4 @@
-name: 2024-2.2-py311-tiled
+name: 2024-2.3-py311-tiled
 channels:
   - conda-forge
 dependencies:
@@ -51,7 +51,7 @@ dependencies:
   - dpcmaps
   # - edrixs  # conflicts caused by the latest numexpr, to resolve later.
   - eiger-io
-  - event-model >=1.20
+  - event-model >=1.21
   - fabio
   - ffmpeg >=4.0
   - flake8

--- a/envs/env-py311.yml
+++ b/envs/env-py311.yml
@@ -45,7 +45,7 @@ dependencies:
   - databroker >=2.0.0b45
   - dictdiffer
   - diffpy.pdffit2
-  # - diffpy.pdfgui. # fails to build the env with py311
+  - diffpy.pdfgui
   - diffpy.structure
   - discorpy
   - distributed

--- a/envs/env-py311.yml
+++ b/envs/env-py311.yml
@@ -45,7 +45,7 @@ dependencies:
   - databroker >=2.0.0b45
   - dictdiffer
   - diffpy.pdffit2
-  - diffpy.pdfgui
+  # - diffpy.pdfgui. # fails to build the env with py311
   - diffpy.structure
   - discorpy
   - distributed

--- a/envs/env-py311.yml
+++ b/envs/env-py311.yml
@@ -45,6 +45,7 @@ dependencies:
   - databroker >=2.0.0b45
   - dictdiffer
   - diffpy.pdffit2
+  - diffpy.pdfgui
   - diffpy.structure
   - discorpy
   - distributed

--- a/envs/env-py311.yml
+++ b/envs/env-py311.yml
@@ -79,6 +79,7 @@ dependencies:
   - ispyb
   - isstools
   - jedi
+  - julia
   - jupyter
   - jupyterlab
   - ldap3

--- a/envs/env-py311.yml
+++ b/envs/env-py311.yml
@@ -203,36 +203,37 @@ dependencies:
   #            Dependencies from the `nsls2-collection` metapackage           #
   #                                                                           #
   #***************************************************************************#
-  - bloptools >=0.7.0
-  - bluesky-darkframes >=0.6.0
-  - caproto
-  - emojis
-  - happi
-  - pexpect
-  # - pydm
-  - pyolog >=4.5.0
-  - pyserial
-  - python-confluent-kafka
-  - pyzenodo3
-  - simple-pid
-  - slack-sdk
-  # Beamline-specific packages
-  - hklpy  # [linux]
-  - hxnfly >=0.0.11
-  - kkcalc
-  - ppmac
-  - pychx >=4.3.1
-  - xpdacq ==1.0.0
-  # Debugging tools:
-  - hunter
-  - logging_tree
-  # Profiling tools:
-  - line_profiler
-  - pyinstrument
-  - pyperformance
-  # ML:
-  - botorch
-  - gpytorch
-  - ortools-python
-  - pytorch
-  - scikit-optimize
+  # Those package will be added to the successfully-resolved conda env:
+  # - bloptools >=0.7.0
+  # - bluesky-darkframes >=0.6.0
+  # - caproto
+  # - emojis
+  # - happi
+  # - pexpect
+  # # - pydm
+  # - pyolog >=4.5.0
+  # - pyserial
+  # - python-confluent-kafka
+  # - pyzenodo3
+  # - simple-pid
+  # - slack-sdk
+  # # Beamline-specific packages
+  # - hklpy  # [linux]
+  # - hxnfly >=0.0.11
+  # - kkcalc
+  # - ppmac
+  # - pychx >=4.3.1
+  # - xpdacq ==1.0.0
+  # # Debugging tools:
+  # - hunter
+  # - logging_tree
+  # # Profiling tools:
+  # - line_profiler
+  # - pyinstrument
+  # - pyperformance
+  # # ML:
+  # - botorch
+  # - gpytorch
+  # - ortools-python
+  # - pytorch
+  # - scikit-optimize

--- a/envs/env-py311.yml
+++ b/envs/env-py311.yml
@@ -33,6 +33,7 @@ dependencies:
   - cmasher
   - conda-pack
   - conftrak >=0.0.9
+  - cookiecutter
   - csxtools >=0.2.1
   - dash
   - dash-bootstrap-components

--- a/envs/env-py311.yml
+++ b/envs/env-py311.yml
@@ -124,6 +124,7 @@ dependencies:
   - py-xgboost
   - py4xs
   - pycentroids
+  - pycryptodome
   - pyepics >=3.4.2
   - pyfai >=2024.5.0
   - pyfftw

--- a/envs/env-py312.yml
+++ b/envs/env-py312.yml
@@ -124,6 +124,7 @@ dependencies:
   - py-xgboost
   - py4xs
   - pycentroids
+  - pycryptodome
   - pyepics >=3.4.2
   - pyfai >=2024.5.0
   # - pyfftw  # no build for py312 as of 2024-06-20

--- a/envs/env-py312.yml
+++ b/envs/env-py312.yml
@@ -45,7 +45,7 @@ dependencies:
   - databroker >=2.0.0b45
   - dictdiffer
   - diffpy.pdffit2
-  - diffpy.pdfgui
+  # - diffpy.pdfgui  # no package for py312
   - diffpy.structure
   - discorpy
   - distributed

--- a/envs/env-py312.yml
+++ b/envs/env-py312.yml
@@ -1,4 +1,4 @@
-name: 2024-2.2-py312-tiled
+name: 2024-2.3-py312-tiled
 channels:
   - conda-forge
 dependencies:
@@ -51,7 +51,7 @@ dependencies:
   - dpcmaps
   # - edrixs  # conflicts caused by the latest numexpr, to resolve later.
   - eiger-io
-  - event-model >=1.20
+  - event-model >=1.21
   - fabio
   - ffmpeg >=4.0
   - flake8

--- a/envs/env-py312.yml
+++ b/envs/env-py312.yml
@@ -45,6 +45,7 @@ dependencies:
   - databroker >=2.0.0b45
   - dictdiffer
   - diffpy.pdffit2
+  - diffpy.pdfgui
   - diffpy.structure
   - discorpy
   - distributed

--- a/envs/env-py312.yml
+++ b/envs/env-py312.yml
@@ -79,6 +79,7 @@ dependencies:
   - ispyb
   - isstools
   - jedi
+  - julia
   - jupyter
   - jupyterlab
   - ldap3

--- a/envs/env-py312.yml
+++ b/envs/env-py312.yml
@@ -33,6 +33,7 @@ dependencies:
   - cmasher
   - conda-pack
   - conftrak >=0.0.9
+  - cookiecutter
   - csxtools >=0.2.1
   - dash
   - dash-bootstrap-components


### PR DESCRIPTION
Pins `event-model` >=1.21 and adds `cookiecutter`.

Closes https://github.com/nsls2-conda-envs/nsls2-collection-tiled/issues/40.


Diffs:
<details>

```diff
diff envs/env-py311.yml envs/env-py312.yml
1c1
< name: 2024-2.3-py311-tiled
---
> name: 2024-2.3-py312-tiled
10c10
<   - python >=3.11,<3.12
---
>   - python >=3.12,<3.13
14c14
<   - ansiwrap
---
>   # - ansiwrap
48c48
<   - diffpy.pdfgui
---
>   # - diffpy.pdfgui  # no package for py312
131c131
<   - pyfftw
---
>   # - pyfftw  # no build for py312 as of 2024-06-20
187c187
<   - shadow3 >=23.1.4
---
>   # - shadow3 >=23.1.4
189c189
<   - sirepo-bluesky >=0.6.2
---
>   # - sirepo-bluesky >=0.6.2
194a195
>     - ansiwrap
195a197
>     - bloptools >=0.7.0
198c200
<     - ophyd-async[ca,pva]
---
>     # - ophyd-async[ca]
206d207
<   - bloptools >=0.7.0
236c237
<   - ortools-python
---
>   # - ortools-python
```
</details>