### PR TITLE
CI housekeeping

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -103,15 +103,15 @@ jobs:
           echo "artifact_py${{ env.PYTHONVER }}=${ARTIFACT_FILE_NAME}" >> $GITHUB_OUTPUT
           echo "conda_pack_env_py${{ env.PYTHONVER }}=${CONDA_PACK_ENV_NAME}" >> $GITHUB_OUTPUT
 
+      - name: Remove system-wide condarc
+        run: |
+          sudo rm -f /usr/share/miniconda/.condarc
+
       - name: Setup umamba
         uses: mamba-org/setup-micromamba@v2
         with:
           environment-file: envs/env-py${{ env.PYTHONVER }}.yml
           log-level: info
-          condarc: |
-            channels:
-              - conda-forge
-              - nodefaults
         env:
           CONDA_OVERRIDE_GLIBC: "2.28"
 


### PR DESCRIPTION
It turned out that the CI had the system-wide condarc configured with the `defaults` channel in it. Even though we don't use it for packaging, the exported .yml files contained `defaults` in the list of channels. The only (quick) way to properly get rid of that channel was to remove the config file as we want to fully control what channels to use.