### PR TITLE
Update package.yml to work on pull requests

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-  pull_request_target:
+  pull_request:
   workflow_dispatch:
   release:
     types: [published]


### PR DESCRIPTION
Closes #77 

This should run on every push to a PR. It will *not* run on a push to a branch that isn't `main`. This is to avoid duplicate tests running (one for the push event and one for the pull request sync event).